### PR TITLE
Fix issues 4 and 5

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,8 @@ import ColorConverter from './components/ColorConverter';
 import TextPropertiesGenerator from './components/TextPropertiesGenerator';
 import TransformGenerator from './components/TransformGenerator';
 import LoadingSpinner from './components/LoadingSpinner';
+import CssMinifier from './components/CssMinifier';
+import JsMinifier from './components/JsMinifier';
 
 export default function App() {
   const [activeTool, setActiveTool] = useState('box-shadow-generator');
@@ -55,6 +57,10 @@ export default function App() {
         return <TextPropertiesGenerator />;
       case 'transform-generator':
         return <TransformGenerator />;
+      case 'css-minifier':
+        return <CssMinifier />;
+      case 'js-minifier':
+        return <JsMinifier />;
       default:
         return <BoxShadowGenerator />;
     }

--- a/src/components/CodeOutput.jsx
+++ b/src/components/CodeOutput.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { dracula } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
-const CodeOutput = ({ code }) => {
+const CodeOutput = ({ code, codeLanguage = 'css'}) => {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
@@ -12,12 +12,13 @@ const CodeOutput = ({ code }) => {
     });
   };
 
+
   return (
     <div className="tool-code-output">
       <button className="btn btn-sm btn-secondary copy-btn" title="Copy" onClick={handleCopy}>
         <i className={`bi ${copied ? 'bi-check-lg' : 'bi-clipboard'}`}></i>
       </button>
-      <SyntaxHighlighter language="css" style={dracula}>
+      <SyntaxHighlighter language={codeLanguage} style={dracula}>
         {code}
       </SyntaxHighlighter>
     </div>

--- a/src/components/CssMinifier.jsx
+++ b/src/components/CssMinifier.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import CodeOutput from './CodeOutput';
+
+export function minifier(code){
+    return code.replaceAll(" ","").replaceAll(/\/\*.*?\*\//g, "").replaceAll("\n", "")
+}
+
+const CssMinifier = () => {
+  
+    const [cssText, setCssText] = useState()
+    const [minifiedCss, setMinifiedCss] = useState()
+
+  return (
+    <div className="container">
+      <div className="card-body p-3">
+        <h4 className="card-title mb-4">Css Minifier</h4>
+        <div className="row g-4">
+          <div className="col-lg-5">
+            <div className="d-flex flex-column gap-3">
+              <div>
+                <label htmlFor="inputCss" className="form-label">Input Css</label>
+                <textarea className="form-control" id="inputCss" rows="3" placeholder="css code" value={cssText} onChange={e => setCssText(e.target.value)}></textarea>
+                <button type="button" class="btn btn-primary mt-3" onClick={() => setMinifiedCss(minifier(cssText))}>Primary</button>
+              </div>
+            </div>
+          </div>
+          <div className="col-lg-7">
+            <CodeOutput code={minifiedCss}/>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CssMinifier;

--- a/src/components/JsMinifier.jsx
+++ b/src/components/JsMinifier.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import CodeOutput from './CodeOutput';
+import { minifier } from "./CssMinifier";
+
+const JsMinifier = () => {
+  
+    const [jsText, setJsText] = useState()
+    const [minifiedJs, setMinifiedJs] = useState()
+    
+
+  return (
+    <div className="container">
+      <div className="card-body p-3">
+        <h4 className="card-title mb-4">Js Minifier</h4>
+        <div className="row g-4">
+          <div className="col-lg-5">
+            <div className="d-flex flex-column gap-3">
+              <div>
+                <label htmlFor="inputJs" className="form-label">Input Js</label>
+                <textarea className="form-control" id="inputJs" rows="3" placeholder="js code" value={jsText} onChange={e => setJsText(e.target.value)}></textarea>
+                <button type="button" class="btn btn-primary mt-3" onClick={() => setMinifiedJs(minifier(jsText))}>Primary</button>
+              </div>
+            </div>
+          </div>
+          <div className="col-lg-7">
+            <CodeOutput code={minifiedJs} codeLanguage="javascript"/>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default JsMinifier;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -9,6 +9,8 @@ const Sidebar = ({ activeTool, setActiveTool, theme, toggleTheme, isOpen, toggle
     { id: 'color-converter', name: 'Color Converter', icon: 'bi-eyedropper' },
     { id: 'text-properties-generator', name: 'Text Properties', icon: 'bi-textarea-t' },
     { id: 'transform-generator', name: 'Transform', icon: 'bi-arrows-move' },
+    { id: 'css-minifier', name: 'Css Minifier', icon: 'bi-arrows-move' },
+    { id: 'js-minifier', name: 'Js Minifier', icon: 'bi-arrows-move' }
   ];
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -162,6 +162,7 @@ body {
 }
 
 .tool-code-output {
+
   position: relative;
   padding: 0rem;
   border-radius: 0.5rem;

--- a/src/index.css
+++ b/src/index.css
@@ -162,7 +162,6 @@ body {
 }
 
 .tool-code-output {
-
   position: relative;
   padding: 0rem;
   border-radius: 0.5rem;

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/'
+  base: '/webdev-toolkit-react'
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: '/webdev-toolkit-react'
+  base: '/'
 })


### PR DESCRIPTION
Summary
This pull request addresses issues #4 and #5 by adding two new components and integrating them into App.js and Sidebar.jsx.

**Changes**

- Created two new components.

- Updated App.js and Sidebar.jsx to include the new components.

- Updated CodeOutput.jsx to support syntax highlighting for JavaScript code by adding an additional prop.

**Notes / Limitations**

- Currently, CodeOutput.jsx displays minified code all on one line with a horizontal scrollbar. This is not ideal for readability since minified code has no newlines.

- A possible solution would be to pass these props to SyntaxHighlighter:
  `lineProps={{ style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' } }} wrapLines={true}`
  However, doing so partially obscures the copy button, making it harder to use. For now, I decided to keep CodeOutput.jsx as it  was to preserve usability.